### PR TITLE
Проброс переменных среды из файла .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,11 @@ services:
   hub_backend:
     build: web/hub_backend
     image: hub-backend
+    environment:
+      - PATH_TO_OSCRIPT_HUB
+      - GITHUB_SUPER_TOKEN
+      - GITTER_OAUTH_TOKEN
+      - GITTER_ROOM
     ports:
       - "9002:9002"
     volumes:


### PR DESCRIPTION
Суть - если docker-compose не видит файла .env в CWD, то эти переменные среды внутри контейнера остаются незаданными. Если видит, то начинает перекидывать из файла значения параметров внутрь контейнера в переменные среды